### PR TITLE
FORMS-275 # compatibility with Underscore 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Change Log
 
 
+## Unreleased
+
+
+### Fixed
+
+-   FORMS-275: compatibility with Underscore 1.6.0
+
+    -   resolves issues caused when older versions introduced by 3rd-party code (e.g. Cordova plugins) replace the default Underscore 1.8.3
+
+    -   HelpDesk: 6090-QETB-0974
+
+
 ## 3.10.2 - 2016-07-18
 
 

--- a/forms/main.js
+++ b/forms/main.js
@@ -29,6 +29,8 @@ define(function (require) {
 
   Forms = window.BMP.Forms;
 
+  require('./polyfill-object-assign.js');
+
   _.extend(Forms, Backbone.Events);
 
   _.extend(Forms, require('forms/events'));
@@ -114,7 +116,8 @@ define(function (require) {
     parsed = Forms.parseClass(klass);
     parsed = _.omit(parsed, blacklist);
 
-    defaults = _.result(model, 'defaults', {});
+    // Underscore 1.6 ignores the 3rd argument for a fallback value
+    defaults = _.result(model, 'defaults', {}) || {};
     model.set(Forms.castPropertyValues(parsed, defaults));
   };
 

--- a/forms/models/elements/date.js
+++ b/forms/models/elements/date.js
@@ -1,15 +1,13 @@
 define(function (require) {
   'use strict';
 
-  var _ = require('underscore');
-
   var ElementModel = require('forms/models/element');
   var moment = require('moment');
 
   return ElementModel.extend({
 
     defaults: function () {
-      return _.assign(ElementModel.prototype.defaults.call(this), {
+      return Object.assign(ElementModel.prototype.defaults.call(this), {
         _time: '',
         _date: ''
       });

--- a/forms/models/elements/file.js
+++ b/forms/models/elements/file.js
@@ -47,7 +47,7 @@ define(function (require) {
 */
   return ElementModel.extend({
     defaults: function () {
-      return _.assign(ElementModel.prototype.defaults.call(this), {
+      return Object.assign(ElementModel.prototype.defaults.call(this), {
         height: 0,
         width: 0,
         progress: null,

--- a/forms/models/elements/heading.js
+++ b/forms/models/elements/heading.js
@@ -2,13 +2,12 @@ define(function (require) {
   'use strict';
 
   var $ = require('jquery');
-  var _ = require('underscore');
 
   var ElementModel = require('forms/models/element');
 
   return ElementModel.extend({
     defaults: function () {
-      return _.assign(ElementModel.prototype.defaults.call(this), {
+      return Object.assign(ElementModel.prototype.defaults.call(this), {
         persist: false,
         level: 1
       });

--- a/forms/models/elements/message.js
+++ b/forms/models/elements/message.js
@@ -1,13 +1,11 @@
 define(function (require) {
   'use strict';
 
-  var _ = require('underscore');
-
   var ElementModel = require('forms/models/element');
 
   return ElementModel.extend({
     defaults: function () {
-      return _.assign(ElementModel.prototype.defaults.call(this), {
+      return Object.assign(ElementModel.prototype.defaults.call(this), {
         persist: false
       });
     },

--- a/forms/models/elements/select.js
+++ b/forms/models/elements/select.js
@@ -12,7 +12,7 @@ define(function (require) {
   // this module
   return ElementModel.extend({
     defaults: function () {
-      return _.assign(ElementModel.prototype.defaults.call(this), {
+      return Object.assign(ElementModel.prototype.defaults.call(this), {
         mode: 'collapsed',
         layout: 'vertical',
         other: false,

--- a/forms/models/elements/subform.js
+++ b/forms/models/elements/subform.js
@@ -44,7 +44,7 @@ define(function (require) {
 
   return ElementModel.extend({
     defaults: function () {
-      return _.assign(ElementModel.prototype.defaults.call(this), {
+      return Object.assign(ElementModel.prototype.defaults.call(this), {
         collapse: 'off'
       });
     },

--- a/forms/models/popups/webcam-popup.js
+++ b/forms/models/popups/webcam-popup.js
@@ -14,7 +14,7 @@ define(function (require) {
 
   return PopupModel.extend({
     defaults: function () {
-      return _.assign(PopupModel.prototype.defaults.call(this), {
+      return Object.assign(PopupModel.prototype.defaults.call(this), {
         orientation: 0,
         rotateBy: 90,
 

--- a/forms/models/subform.js
+++ b/forms/models/subform.js
@@ -1,15 +1,13 @@
 define(function (require) {
   'use strict';
 
-  var _ = require('underscore');
-
   var Form = require('forms/models/form');
 
   // this module
 
   return Form.extend({
     defaults: function () {
-      return _.assign(Form.prototype.defaults.call(this), {
+      return Object.assign(Form.prototype.defaults.call(this), {
         isCollapsed: false
       });
     },

--- a/forms/polyfill-object-assign.js
+++ b/forms/polyfill-object-assign.js
@@ -1,0 +1,29 @@
+define(function () {
+  'use strict';
+
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+  if (typeof Object.assign !== 'function') {
+    Object.assign = function (target, varArgs) { // .length of function is 2
+      'use strict';
+      if (target == null) { // TypeError if undefined or null
+        throw new TypeError('Cannot convert undefined or null to object');
+      }
+
+      var to = Object(target);
+
+      for (var index = 1; index < arguments.length; index++) {
+        var nextSource = arguments[index];
+
+        if (nextSource != null) { // Skip over if undefined or null
+          for (var nextKey in nextSource) {
+            // Avoid bugs when hasOwnProperty is shadowed
+            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+              to[nextKey] = nextSource[nextKey];
+            }
+          }
+        }
+      }
+      return to;
+    };
+  }
+});


### PR DESCRIPTION
### Fixed

-   FORMS-275: compatibility with Underscore 1.6.0

    -   resolves issues caused when older versions introduced by 3rd-party code (e.g. Cordova plugins) replace the default Underscore 1.8.3

    -   HelpDesk: 6090-QETB-0974
